### PR TITLE
bug fixes

### DIFF
--- a/inc/templates-include.php
+++ b/inc/templates-include.php
@@ -1,19 +1,36 @@
 <?php
 
 /**
+ * Returns current template path
+ *
+ * @author Alex Chizhov <ac@alexchizhov.com>
+ * @global string $wp_version Variable stores WordPress version
+ * @since 2.1.0
+ * @return string Current template path
+ */
+function get_goods_directory()
+{
+    global $wp_version;
+
+    return $wp_version >= 4.7 ? get_theme_file_path() : get_stylesheet_directory();
+}
+
+/**
  * Function gets HTML templates, there is a default
  * templates and you can define a custom path
  *
  * @author Alex Chizhov <ac@alexchizhov.com>
  * @param string $custom_templates_path Path to custom templates
+ * @since 2.1.0
  * @return string HTML Template
  */
-function goods_template($custom_templates_path = '') {
-	if ($custom_templates_path && file_exists($custom_templates_path)) {
-		require_once $custom_templates_path;
-	} else {
-		require_once GOODS_CATALOG_PLUGIN_INC . '/templates.php';
-	}
+function goods_template($custom_templates_path = '')
+{
+    if ($custom_templates_path && file_exists($custom_templates_path)) {
+        require_once $custom_templates_path;
+    } else {
+        require_once GOODS_CATALOG_PLUGIN_INC . '/templates.php';
+    }
 }
 
 /**
@@ -22,25 +39,27 @@ function goods_template($custom_templates_path = '') {
  *
  * @author Alex Chizhov <ac@alexchizhov.com>
  * @param string $template
+ * @since 2.1.0
  * @return string
  */
-function goods_wrapper($template) {
-	if (
-		is_post_type_archive('goods') ||
-		is_tax('goods_category') ||
-		is_tax('goods_tag') ||
-		is_singular('goods')
-	) {
+function goods_wrapper($template)
+{
 
-		// Check if there is a wrapper template in child theme
-		if (file_exists(get_stylesheet_directory() . '/goods-wrapper.php')) {
-			$template = get_stylesheet_directory() . '/goods-wrapper.php';
-		} else { // If none found include default wrapper
-			$template = GOODS_CATALOG_PLUGIN_TEMPLATES . '/wrapper.php';
-		}
-	}
+    if (
+            is_post_type_archive('goods') ||
+            is_tax('goods_category') ||
+            is_tax('goods_tag') ||
+            is_singular('goods')
+    ) {
+        // Check if there is a wrapper template in child theme
+        if (file_exists(get_goods_directory() . '/goods-wrapper.php')) {
+            $template = get_goods_directory() . '/goods-wrapper.php';
+        } else { // If none found include default wrapper
+            $template = GOODS_CATALOG_PLUGIN_TEMPLATES . '/wrapper.php';
+        }
+    }
 
-	return $template;
+    return $template;
 }
 
 add_filter('template_include', 'goods_wrapper', 99);
@@ -50,36 +69,41 @@ add_filter('template_include', 'goods_wrapper', 99);
  *
  * @author Alex Chizhov <ac@alexchizhov.com>
  * @param array $category_list
- * @return string HTML template
+ * @since 2.1.0
  */
-function goods_category($category_list) {
+function goods_category($category_list)
+{
+    ob_start();
 
-	ob_start();
+    // Check if there is a wrapper template in child theme
+    if (file_exists(get_goods_directory() . '/content-goods_category.php')) {
+        include get_goods_directory() . '/content-goods_category.php';
+    } else { // If none found include default wrapper
+        include GOODS_CATALOG_PLUGIN_TEMPLATES . '/content-goods_category.php';
+    }
 
-	// Check if there is a wrapper template in child theme
-	if (file_exists(get_stylesheet_directory() . '/content-goods_category.php')) {
+    $template = ob_get_clean();
 
-		include get_stylesheet_directory() . '/content-goods_category.php';
-	} else { // If none found include default wrapper
-		include GOODS_CATALOG_PLUGIN_TEMPLATES . '/content-goods_category.php';
-	}
-
-	$template = ob_get_clean();
-
-	echo $template;
+    echo $template;
 }
 
-function goods_grid() {
-	ob_start();
+/**
+ * Loads template for goods grid
+ *
+ * @author Alex Chizhov <ac@alexchizhov.com>
+ * @since 2.1.0
+ */
+function goods_grid()
+{
+    ob_start();
 
-	if (file_exists(get_stylesheet_directory() . '/content-goods_grid.php')) {
+    if (file_exists(get_goods_directory() . '/content-goods_grid.php')) {
+        include get_goods_directory() . '/content-goods_grid.php';
+    } else { // If none found include default wrapper
+        include GOODS_CATALOG_PLUGIN_TEMPLATES . '/content-goods_grid.php';
+    }
 
-		include get_stylesheet_directory() . '/content-goods_grid.php';
-	} else { // If none found include default wrapper
-		include GOODS_CATALOG_PLUGIN_TEMPLATES . '/content-goods_grid.php';
-	}
+    $template = ob_get_clean();
 
-	$template = ob_get_clean();
-
-	echo $template;
+    echo $template;
 }

--- a/templates/content-goods_category.php
+++ b/templates/content-goods_category.php
@@ -41,7 +41,16 @@ else {
 					<div class="goods-category-thumb-container">
 
 						<?php
-						$terms = apply_filters('taxonomy-images-get-terms', '', array('taxonomy' => 'goods_category'));
+                                                /**
+                                                 * Added term_args parameter to show images for categories that are empty
+                                                 *
+                                                 * hide_empty set to false
+                                                 * https://developer.wordpress.org/reference/functions/get_terms/
+                                                 *
+                                                 * @sinse 2.1.0
+                                                 */
+						$terms = apply_filters('taxonomy-images-get-terms', '', array('taxonomy' => 'goods_category', 'term_args' => array('hide_empty' => false)));
+
 						$flag = FALSE;
 						if (!empty($terms)) {
 							foreach ((array) $terms as $term) {

--- a/templates/content-goods_grid.php
+++ b/templates/content-goods_grid.php
@@ -16,7 +16,7 @@ if (have_posts()) {
 		?>
 		<div class="grid">
 			<article <?php post_class(); ?>>
-				<div class="goods-item-title"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></div>
+				<div class="goods-item-title"><a href="<?php esc_url(the_permalink()); ?>"><?php the_title(); ?></a></div>
 				<div class="goods-item-content">
 					<?php
 					// show thumbnails

--- a/templates/single-goods.php
+++ b/templates/single-goods.php
@@ -15,19 +15,20 @@ if (have_posts()) {
 
 		<article <?php post_class(); ?>>
 			<header>
-				<?php
-				echo '<div class="goods-single-thumb-container">';
-				if (has_post_thumbnail()) {
-					$large_image_url = wp_get_attachment_image_src(get_post_thumbnail_id(), 'large');
-					echo '<a href="' . $large_image_url[0] . '" title="' . the_title_attribute('echo=0') . '" >';
-					the_post_thumbnail('medium', array('class' => 'goods-single-thumb'));
-					echo '</a>';
-				} else {
-					// show default image if the thumbnail is not found
-					echo '<img class="goods-item-thumb" src="' . plugins_url('/img/gi.png', dirname(__FILE__)) . '" alt="">';
-				}
-				echo '</div>';
-				?>
+                                <div class="goods-single-thumb-container">
+                                        <?php
+                                        echo '';
+                                        if (has_post_thumbnail()) {
+                                                $large_image_url = wp_get_attachment_image_src(get_post_thumbnail_id(), 'large');
+                                                echo '<a href="' . esc_url($large_image_url[0]) . '" title="' . esc_attr(the_title_attribute('echo=0')) . '" >';
+                                                the_post_thumbnail('medium', array('class' => 'goods-single-thumb'));
+                                                echo '</a>';
+                                        } else {
+                                                // show default image if the thumbnail is not found
+                                                echo '<img class="goods-item-thumb" src="' . esc_url(plugins_url('/img/gi.png', dirname(__FILE__))) . '" alt="">';
+                                        }
+                                        ?>
+				</div>
 				<div class="goods-info">
 					<h2 class="entry-title"><?php the_title(); ?></h2>
 					<?php


### PR DESCRIPTION
Протестировал с плагином Taxonomy Images на свежей установке WP со стандартной темой Twenty Seventeen. Добавил новую функцию в template-include, и для taxonomy category подправил отображение изображений категорий в которых нет товаров